### PR TITLE
Refresh token jwk

### DIFF
--- a/middleWare/middleAuth.mjs
+++ b/middleWare/middleAuth.mjs
@@ -1,31 +1,33 @@
 import { users } from '../mongo.mjs';
 
-export let middleAuth = (req, res, next) => {
+export const middleAuth = (req, res, next) => {
   // 인증처리
 
   // 클라이언트 로컬스토리지에서 토큰 가져오기
   // 클라이언트로부터 'Authorization' 헤더를 읽어옴
   const authHeader = req.headers['authorization'];
-
+  const refreshToken = req.headers['x-refresh-token'];
+  // 클라이언트로부터 _id 읽어옴
+  const _id = req.query._id;
   // 'Authorization' 헤더가 존재하고, 'Bearer' 스키마를 사용한 경우에만 처리
   if (authHeader && authHeader.startsWith('Bearer ')) {
-    const token = authHeader.split(' ')[1]; // 'Bearer ' 다음의 토큰 부분을 추출
+    const accessToken = authHeader.split(' ')[1]; // 'Bearer ' 다음의 토큰 부분을 추출
     // findByToken 을 사용해 토큰을 복호화하고 해당 유저를 DB에서 찾기
     // 토큰을 서버에 저장하지말고 클라이언트로부터 _id를 같이 받아서 복호화한 jwt토큰과 _id가 일치하는지 확인
     users
-      .findByToken(token)
-      .then((foundUser) => {
-        if (!foundUser) {
-          return res.json({ isLogin: false });
+      .findByToken(accessToken, refreshToken)
+      .then((decodedId) => {
+        if (!_id || decodedId !== _id) {
+          req.isLogin = false; // 인증 실패 시 isLogin 값을 false로 설정
+          next();
+        } else {
+          req.isLogin = true; // 인증 성공 시 isLogin 값을 true로 설정
+          next();
         }
-        req.token = token;
-        req.foundUser = foundUser;
-        next();
       })
       .catch((err) => {
         console.log('middleAuth', err);
       });
-    // 유저가 있으면 인증
   } else {
     // 'Authorization' 헤더가 없거나 올바른 스키마를 사용하지 않은 경우에 대한 처리
     return res.status(401).json({ error: 'Unauthorized' });

--- a/middleWare/middleAuth.mjs
+++ b/middleWare/middleAuth.mjs
@@ -6,7 +6,9 @@ export const middleAuth = (req, res, next) => {
   // 클라이언트 로컬스토리지에서 토큰 가져오기
   // 클라이언트로부터 'Authorization' 헤더를 읽어옴
   const authHeader = req.headers['authorization'];
-  const refreshToken = req.headers['x-refresh-token'];
+
+  //쿠키에 저장된 refreshToken 읽어옴
+  const refreshToken = req.cookies['refreshToken'];
   // 클라이언트로부터 _id 읽어옴
   const _id = req.query._id;
   // 'Authorization' 헤더가 존재하고, 'Bearer' 스키마를 사용한 경우에만 처리
@@ -16,13 +18,19 @@ export const middleAuth = (req, res, next) => {
     // 토큰을 서버에 저장하지말고 클라이언트로부터 _id를 같이 받아서 복호화한 jwt토큰과 _id가 일치하는지 확인
     users
       .findByToken(accessToken, refreshToken)
-      .then((decodedId) => {
-        if (!_id || decodedId !== _id) {
+      .then((newAccessToken) => {
+        if (!newAccessToken) {
           req.isLogin = false; // 인증 실패 시 isLogin 값을 false로 설정
           next();
         } else {
-          req.isLogin = true; // 인증 성공 시 isLogin 값을 true로 설정
-          next();
+          if (newAccessToken === _id) {
+            req.isLogin = true;
+            next();
+          } else {
+            req.isLogin = true; // 인증 성공 시 isLogin 값을 true로 설정
+            req.accessToken = newAccessToken;
+            next();
+          }
         }
       })
       .catch((err) => {

--- a/mongo.mjs
+++ b/mongo.mjs
@@ -19,47 +19,79 @@ mongoose
     console.error('MongoDB 연결 실패: ', error);
   });
 
-// JWT 토큰 생성
+// JWT 리프레쉬 토큰 생성
 usersSchema.methods.generateToken = function (cb) {
-  const tokenExpTime = '1h'; // jwt 토큰 만료시간 지정
+  // 리프레쉬토큰과 엑세스 토큰의 만료시간을 동일하게해 리프레쉬토큰의 보안을 강화
+  const refreshTokenExpTime = '10m'; // jwt 리프레쉬토큰 만료시간 지정
+  const accessTokenExpTime = '10m'; // jwt 엑세스토큰 만료시간 지정
   const tokenExp = new Date();
-  const secretKey = 'team6mongo';
-
-  tokenExp.setMinutes(tokenExp.getMinutes() + 60); // 현재 시간에 60분을 추가
+  const refreshSecretKey = 'team6mongoRefresh';
+  const accessSecretKey = 'team6mongoAccess';
+  tokenExp.setMinutes(tokenExp.getMinutes() + 10); // 현재 시간에 10분을 추가
   // 사용자의 ID를 토큰 페이로드로 설정합니다.
   const payload = {
     _id: this._id, // 예: 사용자의 MongoDB _id
   };
-  // 'team6mongo' 는 key로서 보안관리 필요
-  let token = jwt.sign(payload, secretKey, {
-    expiresIn: tokenExpTime,
+  // 'team6mongoRefresh' 는 key로서 보안관리 필요
+  const refreshToken = jwt.sign(payload, refreshSecretKey, {
+    expiresIn: refreshTokenExpTime,
   });
-  this.token = token;
+  const accessToken = jwt.sign(payload, accessSecretKey, {
+    expiresIn: accessTokenExpTime,
+  });
+  this.token = refreshToken;
   this.tokenExp = tokenExp;
   // mongoDB에 토큰 저장하는부분
   this.save()
     .then((data) => {
-      cb(null, data);
+      cb(null, data, accessToken);
     })
     .catch((err) => {
       cb(err);
     });
 };
 
-// 토큰 복호화
-
-usersSchema.statics.findByToken = async function (token) {
-  const thisUser = this;
-  const secretKey = 'team6mongo';
+// 엑세스 토큰 복호화, 엑세스 토큰 만료됐을때 리프레쉬토큰 쿠키로부터 받아와서 재발급
+usersSchema.statics.findByToken = async function (accessToken, refreshToken) {
+  const accessSecretKey = 'team6mongoAccess';
+  const refreshSecretKey = 'team6mongoRefresh';
   try {
-    const decoded = await jwt.verify(token, secretKey); // _id 기반으로 jwt토큰을 만들었기때문에 디코드하면 _id가 나옴
-    const user = await thisUser.findOne({
-      _id: decoded._id,
-      token: token,
-    });
-    return user;
+    const decoded = await jwt.verify(accessToken, accessSecretKey);
+    return decoded._id;
   } catch (err) {
     console.error('Error in findByToken:', err);
+
+    // 만료된 경우 리프레시 토큰을 검사하고 새로운 엑세스 토큰 발급
+    if (err.name === 'TokenExpiredError') {
+      if (refreshToken) {
+        try {
+          // 리프레쉬 코인 만료여부 조사
+          const decodedRefreshToken = await jwt.verify(
+            refreshToken,
+            refreshSecretKey
+          );
+          // 리프레쉬토큰을 decode 한 결과의 _id와 서버에 저장된 refresh 토큰의 일치여부를 확인
+          const user = await this.findOne({
+            _id: decodedRefreshToken._id,
+            token: refreshToken,
+          });
+          if (user) {
+            // 리프레시 토큰이 유효한 경우, 새로운 엑세스 토큰 발급
+            const newAccessToken = jwt.sign(
+              { _id: decodedRefreshToken._id },
+              accessSecretKey,
+              { expiresIn: '10m' }
+            );
+            // 새로운 엑세스 토큰을 클라이언트에게 보내줍니다 (예: res.cookie('accessToken', newAccessToken))
+            return newAccessToken;
+          } else {
+            console.error('User not found for refreshToken:', refreshToken);
+          }
+        } catch (refreshTokenError) {
+          console.error('Error in verifying refreshToken:', refreshTokenError);
+        }
+      }
+    }
     return null;
   }
 };

--- a/mongo.mjs
+++ b/mongo.mjs
@@ -114,7 +114,7 @@ export const projidcounter = mongoose.model(
 function updateProjStatus() {
   const currentTime = new Date();
   const filter = {
-    'projFundDate.0.projFundEndDate': { $lte: currentTime },
+    'projFundDate.0.projFundEndDate': { $lte: currentTime.toISOString() },
   };
 
   const update = {

--- a/mongo.mjs
+++ b/mongo.mjs
@@ -23,7 +23,7 @@ mongoose
 usersSchema.methods.generateToken = function (cb) {
   // 리프레쉬토큰과 엑세스 토큰의 만료시간을 동일하게해 리프레쉬토큰의 보안을 강화
   const refreshTokenExpTime = '10m'; // jwt 리프레쉬토큰 만료시간 지정
-  const accessTokenExpTime = '10m'; // jwt 엑세스토큰 만료시간 지정
+  const accessTokenExpTime = '1m'; // jwt 엑세스토큰 만료시간 지정
   const tokenExp = new Date();
   const refreshSecretKey = 'team6mongoRefresh';
   const accessSecretKey = 'team6mongoAccess';
@@ -55,6 +55,7 @@ usersSchema.methods.generateToken = function (cb) {
 usersSchema.statics.findByToken = async function (accessToken, refreshToken) {
   const accessSecretKey = 'team6mongoAccess';
   const refreshSecretKey = 'team6mongoRefresh';
+  const accessTokenExpTime = '10s'; // jwt 엑세스토큰 만료시간 지정
   try {
     const decoded = await jwt.verify(accessToken, accessSecretKey);
     return decoded._id;
@@ -65,6 +66,7 @@ usersSchema.statics.findByToken = async function (accessToken, refreshToken) {
     if (err.name === 'TokenExpiredError') {
       if (refreshToken) {
         try {
+          console.log('---------------------------------------------------');
           // 리프레쉬 코인 만료여부 조사
           const decodedRefreshToken = await jwt.verify(
             refreshToken,
@@ -80,7 +82,7 @@ usersSchema.statics.findByToken = async function (accessToken, refreshToken) {
             const newAccessToken = jwt.sign(
               { _id: decodedRefreshToken._id },
               accessSecretKey,
-              { expiresIn: '10m' }
+              { expiresIn: accessTokenExpTime }
             );
             // 새로운 엑세스 토큰을 클라이언트에게 보내줍니다 (예: res.cookie('accessToken', newAccessToken))
             return newAccessToken;

--- a/mongo.mjs
+++ b/mongo.mjs
@@ -67,7 +67,6 @@ usersSchema.statics.findByToken = async function (accessToken, refreshToken) {
     if (err.name === 'TokenExpiredError') {
       if (refreshToken) {
         try {
-          console.log('---------------------------------------------------');
           // 리프레쉬 코인 만료여부 조사
           const decodedRefreshToken = await jwt.verify(
             refreshToken,
@@ -148,8 +147,8 @@ function removeExpiredTokens() {
     });
 }
 
-//60초마다 함수 실행
-cron.schedule('*/60 * * * * *', () => {
-  updateProjStatus();
-  removeExpiredTokens();
-});
+//10분마다 함수 실행
+//cron.schedule('*/10 * * * *', () => {
+//  updateProjStatus();
+//  removeExpiredTokens();
+//});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express-session": "^1.17.3",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.0",
+        "node-cron": "^3.0.2",
         "nodemailer": "^6.9.6",
         "nodemon": "^3.0.1",
         "passport": "^0.6.0",
@@ -1287,6 +1288,17 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
+    "node_modules/node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2041,6 +2053,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express-session": "^1.17.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.0",
+    "node-cron": "^3.0.2",
     "nodemailer": "^6.9.6",
     "nodemon": "^3.0.1",
     "passport": "^0.6.0",

--- a/server.mjs
+++ b/server.mjs
@@ -141,10 +141,10 @@ app.post('/login/kakao', async (req, res) => {
 // 네이버 로그인 부분
 
 // 로그아웃 부분
-app.get('/logout', middleAuth, async (req, res) => {
+app.post('/logout', async (req, res) => {
   try {
     const logoutUser = await users.findOneAndUpdate(
-      { _id: req.foundUser._id }, // middleAuth 의 foundUser
+      { _id: req.body._id }, // middleAuth 의 foundUser
       {
         $set: {
           token: '',
@@ -155,9 +155,8 @@ app.get('/logout', middleAuth, async (req, res) => {
     if (!logoutUser) {
       return res.json({ logoutSuccess: false });
     }
-    res.clearCookie('accessToken');
     res.clearCookie('refreshToken');
-    return res.status(200).send({ logoutSuccess: true });
+    res.status(200).send({ logoutSuccess: true });
   } catch (err) {
     return res.json({ logoutSuccess: false, err });
   }

--- a/server.mjs
+++ b/server.mjs
@@ -155,6 +155,8 @@ app.get('/logout', middleAuth, async (req, res) => {
     if (!logoutUser) {
       return res.json({ logoutSuccess: false });
     }
+    res.clearCookie('accessToken');
+    res.clearCookie('refreshToken');
     return res.status(200).send({ logoutSuccess: true });
   } catch (err) {
     return res.json({ logoutSuccess: false, err });
@@ -616,10 +618,14 @@ app.get('/auth', middleAuth, async (req, res) => {
   try {
     if (req.isLogin === false) {
       // 인증에 실패한 경우
-      res.status(200).json({ isLogin: false });
+      res.status(200).json({ isLogin: false, accessToken: '' });
     } else {
-      // 인증에 성공한 경우
-      res.status(200).json({ isLogin: true });
+      // 리프레쉬토큰으로 엑세스토큰을 재발급받았을때와 엑세스토큰이 만료안됐을때 처리
+      if (req.accessToken !== undefined) {
+        res.status(200).json({ isLogin: true, accessToken: req.accessToken });
+      } else {
+        res.status(200).json({ isLogin: true, accessToken: '' });
+      }
     }
   } catch (err) {
     console.log('server.mjs', err);


### PR DESCRIPTION
 기존 JWT 토큰 이용방식은 엑세스토큰만 운용하며 몽고DB에 저장해서 일일이 유저를 다 확인하고 만료까지 서버에서 다 관리
    -> 엑세스토큰, 리프레쉬토큰을 같이 운용하고 엑세스토큰은 몽고DB에 저장하지않고 유효성만 확인하며, 리프레쉬토큰은 서버에 저장
    -> 엑세스토큰이 만료돼도 리프레쉬토큰이 만료되지 않았다면 자동적으로 엑세스토큰을 재발급 해주도록 바꿈